### PR TITLE
.NET 5 fix: Filter out ref structs (IsByRefLikeAttribute)

### DIFF
--- a/TypeConvert.Tests/TypeConvert.Tests.csproj
+++ b/TypeConvert.Tests/TypeConvert.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>net5.0</TargetFrameworks>
 		<Authors>Denis Zykov</Authors>
 		<Version>0.0.0</Version>
 		<PackageId>TypeConvert.Tests</PackageId>


### PR DESCRIPTION
So, I just downloaded the latest Visual Studio with .NET 5.0, and migrated some of my personal projects to try stuff out. But the first thing I notice is TypeConvert started failing.

It turns out .NET 5 now includes many methods that work with ReadOnlySpans, and those can't be put in generic types.

The solution is to filter out ref structs (marked as IsByRefLikeAttribute) whenever we request a list of methods or constructors.